### PR TITLE
fix(profile): use correct server client for updates and persist phone

### DIFF
--- a/src/app/profile/_actions/update-profile.ts
+++ b/src/app/profile/_actions/update-profile.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { createClient } from "@/services/supabase/client";
+import { createClient } from "@/services/supabase/server";
 import { type ProfileFormValues } from "@/components/profile-form";
 
 export async function updateProfile(values: ProfileFormValues) {
-  const client = createClient({});
+  const client = await createClient();
   const { data: user } = await client.auth.getUser();
 
   const { error } = await client
@@ -15,6 +15,7 @@ export async function updateProfile(values: ProfileFormValues) {
       bio: values.bio,
       company: values.company,
       location: values.location,
+      phone: values.phone,
       github_url: values.github_url,
       site_url: values.site_url,
       linkedin_url: values.linkedin_url,

--- a/src/app/profile/_components/profile-form-container.tsx
+++ b/src/app/profile/_components/profile-form-container.tsx
@@ -52,6 +52,7 @@ export function ProfileFormContainer() {
       bio: profile?.bio || "",
       company: profile?.company || "",
       location: profile?.location || "",
+      phone: profile?.phone || "",
       github_url: profile?.github_url || "",
       site_url: profile?.site_url || "",
       linkedin_url: profile?.linkedin_url || "",


### PR DESCRIPTION
O perfil não salvava nenhuma informação porque a server action de atualização estava instanciando o cliente do Supabase incorreto (versão de navegador em vez de servidor), o que fazia com que a sessão do usuário fosse perdida e a operação falhasse silenciosamente por falta de permissão. Além disso, o campo de telefone não estava mapeado no envio nem no carregamento.